### PR TITLE
Allow using rtk create api settings when creating api

### DIFF
--- a/.changeset/brave-avocados-rest.md
+++ b/.changeset/brave-avocados-rest.md
@@ -1,0 +1,5 @@
+---
+"trpc-rtk-query": patch
+---
+
+Allow using rtk query create api settings when creating new api


### PR DESCRIPTION
Unfortunately this api is still is a bit awkward, since we can't support infering just `AppRouter` but not `ReducerPath` (or other args) if using single function. 