### PR TITLE
Use correct pnpm version in release workflow

### DIFF
--- a/.changeset/green-kings-end.md
+++ b/.changeset/green-kings-end.md
@@ -1,0 +1,5 @@
+---
+"trpc-rtk-query": patch
+---
+
+Use correct pnpm version in release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8.6.5
+          version: 9.4.0
 
       - name: Setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Updates pnpm to 9.4.0 in release workflow as well.