### PR TITLE
Set packageManager field instead of engines.pnpm

### DIFF
--- a/.changeset/afraid-bats-double.md
+++ b/.changeset/afraid-bats-double.md
@@ -1,0 +1,5 @@
+---
+"trpc-rtk-query": minor
+---
+
+Set packageManager field instead of engines.pnpm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.4.0
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.4.0
 
       - name: Setup node
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "is-what": "^4.1.16"
   },
   "engines": {
-    "node": ">=20",
-    "pnpm": ">=9"
-  }
+    "node": ">=20"
+  },
+  "packageManager": "pnpm@9.6.0"
 }


### PR DESCRIPTION
The packageManager field enables using corepack, a feature native to
Node.js since v18.
That way, it's possible to pnpm install the package with engine-strict
and a different version of pnpm.

Closes #307