### PR TITLE
Upgrade trpc-rtk-query to support tRPC v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install trpc-rtk-query @reduxjs/toolkit @trpc/client @trpc/server
 yarn add trpc-rtk-query @reduxjs/toolkit @trpc/client @trpc/server
 ```
 
-Note the minimum versions for packages, we only support trpc v10 and rtk query v2.
+Note the minimum versions for packages, we support trpc v11 and rtk query v2.
 
 **2. Use your `tRPC router`.**
 
@@ -71,7 +71,7 @@ Create your api [like normal](https://trpc.io/docs/client/vanilla):
 
 ```typescript
 // client.ts
-const client = createTRPCProxyClient<AppRouter>({
+const client = createTRPCClient<AppRouter>({
   links: [
     httpBatchLink({
       url: 'http://localhost:3000/trpc',

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "@changesets/cli": "^2.27.6",
     "@eslint/js": "^9.5.0",
     "@reduxjs/toolkit": "^2.2.5",
-    "@trpc/client": "^10.45.2",
-    "@trpc/server": "^10.45.2",
+    "@trpc/client": "^11.0.0",
+    "@trpc/server": "^11.0.0",
     "@tsconfig/node20": "^20.1.4",
     "@tsconfig/strictest": "^2.0.5",
     "@types/eslint__js": "^8.42.3",
@@ -67,8 +67,8 @@
   },
   "peerDependencies": {
     "@reduxjs/toolkit": "^2.2.1",
-    "@trpc/client": "^10.45.2",
-    "@trpc/server": "^10.45.2"
+    "@trpc/client": "^11.0.0",
+    "@trpc/server": "^11.0.0"
   },
   "dependencies": {
     "is-what": "^5.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,11 +25,11 @@ importers:
         specifier: ^2.2.5
         version: 2.2.5(react-redux@9.1.2(@types/react@18.3.3)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
       '@trpc/client':
-        specifier: ^10.45.2
-        version: 10.45.2(@trpc/server@10.45.2)
+        specifier: ^11.0.0
+        version: 11.7.1(@trpc/server@11.7.1(typescript@5.9.3))(typescript@5.9.3)
       '@trpc/server':
-        specifier: ^10.45.2
-        version: 10.45.2
+        specifier: ^11.0.0
+        version: 11.7.1(typescript@5.9.3)
       '@tsconfig/node20':
         specifier: ^20.1.4
         version: 20.1.5
@@ -1035,13 +1035,16 @@ packages:
     engines: {node: '>=8.10'}
     hasBin: true
 
-  '@trpc/client@10.45.2':
-    resolution: {integrity: sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==}
+  '@trpc/client@11.7.1':
+    resolution: {integrity: sha512-uOnAjElKI892/U6aQMcBHYs3x7mme3Cvv1F87ytBL56rBvs7+DyK7r43zgaXKf13+GtPEI6ex5xjVUfyDW8XcQ==}
     peerDependencies:
-      '@trpc/server': 10.45.2
+      '@trpc/server': 11.7.1
+      typescript: '>=5.7.2'
 
-  '@trpc/server@10.45.2':
-    resolution: {integrity: sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==}
+  '@trpc/server@11.7.1':
+    resolution: {integrity: sha512-N3U8LNLIP4g9C7LJ/sLkjuPHwqlvE3bnspzC4DEFVdvx2+usbn70P80E3wj5cjOTLhmhRiwJCSXhlB+MHfGeCw==}
+    peerDependencies:
+      typescript: '>=5.7.2'
 
   '@tsconfig/node20@20.1.5':
     resolution: {integrity: sha512-Vm8e3WxDTqMGPU4GATF9keQAIy1Drd7bPwlgzKJnZtoOsTm1tduUTbDjg0W5qERvGuxPI2h9RbMufH0YdfBylA==}
@@ -3526,11 +3529,14 @@ snapshots:
       ignore: 5.3.2
       p-map: 4.0.0
 
-  '@trpc/client@10.45.2(@trpc/server@10.45.2)':
+  '@trpc/client@11.7.1(@trpc/server@11.7.1(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
-      '@trpc/server': 10.45.2
+      '@trpc/server': 11.7.1(typescript@5.9.3)
+      typescript: 5.9.3
 
-  '@trpc/server@10.45.2': {}
+  '@trpc/server@11.7.1(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@tsconfig/node20@20.1.5': {}
 

--- a/src/create-endpoint-definitions.ts
+++ b/src/create-endpoint-definitions.ts
@@ -6,7 +6,6 @@ import {
 import {
   type AnyProcedure,
   type AnyRouter,
-  type Procedure,
   type inferProcedureInput,
   type inferProcedureOutput,
 } from "@trpc/server";
@@ -16,12 +15,7 @@ import {
  * @internal
  **/
 type inferProcedureType<TProcedure extends AnyProcedure> =
-  TProcedure extends Procedure<
-    infer ProcedureType,
-    // we don't care about the second param, so it can be any
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    any
-  >
+  TProcedure extends { _def: { type: infer ProcedureType } }
     ? Exclude<ProcedureType, "subscription">
     : never;
 

--- a/src/trpc-client-options.ts
+++ b/src/trpc-client-options.ts
@@ -1,20 +1,20 @@
 import { type BaseQueryApi } from "@reduxjs/toolkit/query/react";
-import { type CreateTRPCProxyClient } from "@trpc/client";
+import { type CreateTRPCClient } from "@trpc/client";
 import { type AnyRouter } from "@trpc/server";
 
 /**
  * TRPC client specific options when creating rtk api. You can either
- *  - pass in already created proxy client or
+ *  - pass in already created client or
  *  - pass in callback that gets access to BaseQueryApi from RTK. This is useful for example when you need to access redux store when creating the client. You can return the client as promise.
  **/
 export type TRPCClientOptions<TRouter extends AnyRouter> =
   | {
-      client: CreateTRPCProxyClient<TRouter>;
+      client: CreateTRPCClient<TRouter>;
       getClient?: never;
     }
   | {
       client?: never;
       getClient: (
         baseQueryApi: BaseQueryApi,
-      ) => Promise<CreateTRPCProxyClient<TRouter>>;
+      ) => Promise<CreateTRPCClient<TRouter>>;
     };

--- a/test/create-trpc-api.test-d.ts
+++ b/test/create-trpc-api.test-d.ts
@@ -1,5 +1,5 @@
 import { createApi, skipToken } from "@reduxjs/toolkit/query/react";
-import { createTRPCProxyClient } from "@trpc/client";
+import { createTRPCClient } from "@trpc/client";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { enhanceApi } from "../src/index.js";
@@ -24,7 +24,7 @@ type QueryRoutes =
 // to copypaste each test case.
 describe("create-trpc-api", () => {
   it("allows injecting trpc api to existing api while infering types from client and api", () => {
-    const client = createTRPCProxyClient<AppRouter>(testClientOptions);
+    const client = createTRPCClient<AppRouter>(testClientOptions);
 
     const api = enhanceApi({
       api: createApi({
@@ -116,7 +116,7 @@ describe("create-trpc-api", () => {
   });
 
   it("allows injecting trpc api to existing api infering types from getclient", () => {
-    const getClient = async () => createTRPCProxyClient<AppRouter>(testClientOptions);
+    const getClient = async () => createTRPCClient<AppRouter>(testClientOptions);
 
     const api = enhanceApi({
       api: createApi({
@@ -206,7 +206,7 @@ describe("create-trpc-api", () => {
   });
 
   it("allows passing options for endpoints when enhancing api", () => {
-    const client = createTRPCProxyClient<AppRouter>(testClientOptions);
+    const client = createTRPCClient<AppRouter>(testClientOptions);
     const existingApi = createApi({
       baseQuery: (string_: string) => {
         return {

--- a/test/create-trpc-api.test.tsx
+++ b/test/create-trpc-api.test.tsx
@@ -1,6 +1,6 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { type BaseQueryApi, createApi } from "@reduxjs/toolkit/query/react";
-import { createTRPCProxyClient } from "@trpc/client";
+import { createTRPCClient } from "@trpc/client";
 import { createHTTPServer } from "@trpc/server/adapters/standalone";
 import { setTimeout } from "node:timers/promises";
 import React from "react";
@@ -23,7 +23,7 @@ type TestServer = {
 
 export const startTestServer = (): Promise<TestServer> =>
   new Promise((resolveCreate) => {
-    const { server } = createHTTPServer({
+    const server = createHTTPServer({
       router: appRouter,
     });
 
@@ -90,7 +90,7 @@ describe("create-trpc-api with pre made api ", () => {
       getApi: () =>
         enhanceApi({
           api: createRTKQueryApiLazily(),
-          client: createTRPCProxyClient<AppRouter>(testClientOptions),
+          client: createTRPCClient<AppRouter>(testClientOptions),
         }),
       testCase: "using passed client",
     },
@@ -103,8 +103,8 @@ describe("create-trpc-api with pre made api ", () => {
             expect(baseQueryApi.type).toBeDefined();
             expect(baseQueryApi.endpoint).toBeDefined();
 
-            // Return proxy client
-            return createTRPCProxyClient<AppRouter>(testClientOptions);
+            // Return client
+            return createTRPCClient<AppRouter>(testClientOptions);
           },
         }),
       testCase: "using getClient to get the client",
@@ -399,7 +399,7 @@ describe("create-trpc-api with pre made api ", () => {
   });
 
   it("doesn't replace previous hooks when passing in and existing api", () => {
-    const client = createTRPCProxyClient<AppRouter>(testClientOptions);
+    const client = createTRPCClient<AppRouter>(testClientOptions);
     const api = enhanceApi({
       api: createRTKQueryApiLazily(),
       client,


### PR DESCRIPTION
- Update @trpc/client and @trpc/server to v11.0.0 in package.json
- Update client creation API from createTRPCProxyClient to createTRPCClient
- Update type definitions to use CreateTRPCClient instead of CreateTRPCProxyClient
- Fix createHTTPServer usage for v11 (no longer returns wrapped server object)
- Update inferProcedureType to use _def.type instead of removed Procedure type
- Update README to reflect v11 support
- All tests passing with tRPC v11.7.1

Fixes #406