### PR TITLE
Convert ESLint config from JavaScript to TypeScript

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is **trpc-rtk-query**, a TypeScript library that automatically generates RTK Query API endpoints from tRPC router setups. It enables type-safe RTK Query hooks from tRPC procedures, perfect for incremental adoption from tRPC to RTK Query.
 
 **Project Status:**
+
 - Library is in **alpha stage** (0.x.x versions) - not production ready
 - **41 stars, 6 forks** - small but engaged community
 - Uses **pnpm** as package manager (minimum Node.js 20)
@@ -16,6 +17,7 @@ This is **trpc-rtk-query**, a TypeScript library that automatically generates RT
 ## Common Development Commands
 
 **Core Development:**
+
 - `pnpm test` - Run all tests using Vitest
 - `pnpm run coverage` - Run tests with coverage report
 - `pnpm run typecheck` - Run TypeScript type checking only (via Vitest)
@@ -23,20 +25,24 @@ This is **trpc-rtk-query**, a TypeScript library that automatically generates RT
 - `pnpm run build` - Build the library using tsup
 
 **Release Management:**
+
 - `pnpm run changeset` - Create a changeset for versioning
 - `pnpm run release` - Build and publish (runs build + changeset publish)
 
 **Code Quality:**
+
 - `pnpm run knip` - Find unused dependencies and exports
 
 **Running Single Tests:**
 Use Vitest's built-in filtering:
+
 - `pnpm test create-trpc-api` - Run tests matching the pattern
 - `pnpm test -- --typecheck.only` - Run only type tests
 
 ## Architecture Overview
 
 **Core Library Structure:**
+
 - `src/api.ts` - Main API with `enhanceApi()` and `createEmptyApi()` functions
 - `src/create-endpoint-definitions.ts` - Complex TypeScript types that transform tRPC router types into RTK Query endpoint definitions
 - `src/wrap-api-to-proxy.ts` - Proxy wrapper that dynamically creates RTK Query endpoints from tRPC client calls
@@ -44,17 +50,20 @@ Use Vitest's built-in filtering:
 - `src/trpc-client-options.ts` - Type definitions for tRPC client configuration
 
 **Key Concepts:**
+
 1. **Type Transformation**: The library uses advanced TypeScript to flatten nested tRPC routers into RTK Query endpoint definitions
 2. **Runtime Proxy**: Uses JavaScript Proxy to intercept property access and dynamically inject RTK Query endpoints
 3. **Endpoint Naming**: Nested routes are flattened with underscore separation (e.g., `nested.deep.getUser` becomes `nested_deep_GetUser`)
 
 **Test Architecture:**
+
 - Uses Vitest with happy-dom environment
 - `test/fixtures.ts` contains a comprehensive test tRPC router with nested routes, queries, and mutations
 - Type-level tests use `.test-d.ts` files for TypeScript assertion testing
 - Integration tests verify the full tRPC → RTK Query transformation
 
 **Build System:**
+
 - Uses `tsup` for building with both CJS and ESM outputs
 - TypeScript builds reference `tsconfig.build.json`
 - Supports both Node.js require() and ESM import()
@@ -68,6 +77,7 @@ The `CreateEndpointDefinitions` type in `create-endpoint-definitions.ts` is the 
 The `wrapApiToProxy` function creates a Proxy that intercepts property access and uses RTK Query's `injectEndpoints` to dynamically add tRPC-backed endpoints at runtime.
 
 **Testing Strategy:**
+
 - Type-level tests ensure the complex type transformations work correctly
 - Integration tests verify the runtime behavior with actual tRPC routers
 - Snapshot testing captures the generated RTK Query endpoint structure
@@ -77,7 +87,9 @@ The `wrapApiToProxy` function creates a Proxy that intercepts property access an
 Based on open GitHub issues, focus development efforts on:
 
 **High Priority (Blocking/Important):**
+
 1. **tRPC v11 Upgrade (#406)** - Major version update needed to stay current
+
    - Review migration guide: https://trpc.io/docs/v11/migration-guide
    - Update dependencies and test compatibility
    - Consider adopting new features (FormData support, streaming queries)
@@ -89,12 +101,10 @@ Based on open GitHub issues, focus development efforts on:
    - Server-side rendering (SSR) example
    - React Native integration example
 
-**Medium Priority (Quality & DX):**
-3. **Improve Documentation (#44)** - Write comprehensive docs and improve README
-4. **ESLint TypeScript Migration (#317)** - Convert flat config when ESLint stabilizes TS support
-5. **E2E Testing (#43)** - Test built library version in real React projects
+**Medium Priority (Quality & DX):** 3. **Improve Documentation (#44)** - Write comprehensive docs and improve README 4. **ESLint TypeScript Migration (#317)** - Convert flat config when ESLint stabilizes TS support 5. **E2E Testing (#43)** - Test built library version in real React projects
 
 **Technical Debt:**
+
 - Fix tagTypes type checking (#64)
 - Improve endpoint options flow through proxy (#47)
 - Add stricter validation for endpointOptions (#46)
@@ -104,16 +114,19 @@ Based on open GitHub issues, focus development efforts on:
 ## Known Issues & Gotchas
 
 **TypeScript Complexity:**
+
 - Advanced type transformations can cause "excessively deep instantiation" errors
 - The `CreateEndpointDefinitions` type is particularly complex - modify carefully
 - Type checking issues with tagTypes and endpoint options still exist
 
 **Dependency Management:**
+
 - Excellent automated updates via Dependabot (95%+ of recent PRs)
 - Watch for major version compatibility issues (previous issues with pnpm versions)
 - Support requires specific minimum versions: tRPC v10+, RTK Query v2+
 
 **Development Workflow:**
+
 - Last major feature development: June 2024 (ESLint 9 migration)
 - Pattern: Bursts of development followed by maintenance-only phases
 - Owner responsive to issues but development happens in cycles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is **trpc-rtk-query**, a TypeScript library that automatically generates RTK Query API endpoints from tRPC router setups. It enables type-safe RTK Query hooks from tRPC procedures, perfect for incremental adoption from tRPC to RTK Query.
 
 **Project Status:**
+
 - Library is in **alpha stage** (0.x.x versions) - not production ready
 - **41 stars, 6 forks** - small but engaged community
 - Uses **pnpm** as package manager (minimum Node.js 20)
@@ -16,6 +17,7 @@ This is **trpc-rtk-query**, a TypeScript library that automatically generates RT
 ## Common Development Commands
 
 **Core Development:**
+
 - `pnpm test` - Run all tests using Vitest
 - `pnpm run coverage` - Run tests with coverage report
 - `pnpm run typecheck` - Run TypeScript type checking only (via Vitest)
@@ -23,20 +25,24 @@ This is **trpc-rtk-query**, a TypeScript library that automatically generates RT
 - `pnpm run build` - Build the library using tsup
 
 **Release Management:**
+
 - `pnpm run changeset` - Create a changeset for versioning
 - `pnpm run release` - Build and publish (runs build + changeset publish)
 
 **Code Quality:**
+
 - `pnpm run knip` - Find unused dependencies and exports
 
 **Running Single Tests:**
 Use Vitest's built-in filtering:
+
 - `pnpm test create-trpc-api` - Run tests matching the pattern
 - `pnpm test -- --typecheck.only` - Run only type tests
 
 ## Architecture Overview
 
 **Core Library Structure:**
+
 - `src/api.ts` - Main API with `enhanceApi()` and `createEmptyApi()` functions
 - `src/create-endpoint-definitions.ts` - Complex TypeScript types that transform tRPC router types into RTK Query endpoint definitions
 - `src/wrap-api-to-proxy.ts` - Proxy wrapper that dynamically creates RTK Query endpoints from tRPC client calls
@@ -44,17 +50,20 @@ Use Vitest's built-in filtering:
 - `src/trpc-client-options.ts` - Type definitions for tRPC client configuration
 
 **Key Concepts:**
+
 1. **Type Transformation**: The library uses advanced TypeScript to flatten nested tRPC routers into RTK Query endpoint definitions
 2. **Runtime Proxy**: Uses JavaScript Proxy to intercept property access and dynamically inject RTK Query endpoints
 3. **Endpoint Naming**: Nested routes are flattened with underscore separation (e.g., `nested.deep.getUser` becomes `nested_deep_GetUser`)
 
 **Test Architecture:**
+
 - Uses Vitest with happy-dom environment
 - `test/fixtures.ts` contains a comprehensive test tRPC router with nested routes, queries, and mutations
 - Type-level tests use `.test-d.ts` files for TypeScript assertion testing
 - Integration tests verify the full tRPC → RTK Query transformation
 
 **Build System:**
+
 - Uses `tsup` for building with both CJS and ESM outputs
 - TypeScript builds reference `tsconfig.build.json`
 - Supports both Node.js require() and ESM import()
@@ -68,6 +77,7 @@ The `CreateEndpointDefinitions` type in `create-endpoint-definitions.ts` is the 
 The `wrapApiToProxy` function creates a Proxy that intercepts property access and uses RTK Query's `injectEndpoints` to dynamically add tRPC-backed endpoints at runtime.
 
 **Testing Strategy:**
+
 - Type-level tests ensure the complex type transformations work correctly
 - Integration tests verify the runtime behavior with actual tRPC routers
 - Snapshot testing captures the generated RTK Query endpoint structure
@@ -77,7 +87,9 @@ The `wrapApiToProxy` function creates a Proxy that intercepts property access an
 Based on open GitHub issues, focus development efforts on:
 
 **High Priority (Blocking/Important):**
+
 1. **tRPC v11 Upgrade (#406)** - Major version update needed to stay current
+
    - Review migration guide: https://trpc.io/docs/v11/migration-guide
    - Update dependencies and test compatibility
    - Consider adopting new features (FormData support, streaming queries)
@@ -89,12 +101,10 @@ Based on open GitHub issues, focus development efforts on:
    - Server-side rendering (SSR) example
    - React Native integration example
 
-**Medium Priority (Quality & DX):**
-3. **Improve Documentation (#44)** - Write comprehensive docs and improve README
-4. **ESLint TypeScript Migration (#317)** - Convert flat config when ESLint stabilizes TS support
-5. **E2E Testing (#43)** - Test built library version in real React projects
+**Medium Priority (Quality & DX):** 3. **Improve Documentation (#44)** - Write comprehensive docs and improve README 4. **ESLint TypeScript Migration (#317)** - Convert flat config when ESLint stabilizes TS support 5. **E2E Testing (#43)** - Test built library version in real React projects
 
 **Technical Debt:**
+
 - Fix tagTypes type checking (#64)
 - Improve endpoint options flow through proxy (#47)
 - Add stricter validation for endpointOptions (#46)
@@ -104,16 +114,19 @@ Based on open GitHub issues, focus development efforts on:
 ## Known Issues & Gotchas
 
 **TypeScript Complexity:**
+
 - Advanced type transformations can cause "excessively deep instantiation" errors
 - The `CreateEndpointDefinitions` type is particularly complex - modify carefully
 - Type checking issues with tagTypes and endpoint options still exist
 
 **Dependency Management:**
+
 - Excellent automated updates via Dependabot (95%+ of recent PRs)
 - Watch for major version compatibility issues (previous issues with pnpm versions)
 - Support requires specific minimum versions: tRPC v10+, RTK Query v2+
 
 **Development Workflow:**
+
 - Last major feature development: June 2024 (ESLint 9 migration)
 - Pattern: Bursts of development followed by maintenance-only phases
 - Owner responsive to issues but development happens in cycles

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,13 +1,15 @@
+import type { Linter } from "eslint";
+
 import eslint from "@eslint/js";
-import eslintConfigPrettier from "eslint-config-prettier"; // TODO: add types
-import eslintPluginPerfectionistRecommendedNatural from "eslint-plugin-perfectionist/configs/recommended-natural"; // TODO: add types
-import eslintPluginUnicorn from "eslint-plugin-unicorn"; // TODO: add types (https://github.com/sindresorhus/eslint-plugin-unicorn/pull/2382)
+import eslintConfigPrettier from "eslint-config-prettier";
+import eslintPluginPerfectionistRecommendedNatural from "eslint-plugin-perfectionist/configs/recommended-natural";
+import eslintPluginUnicorn from "eslint-plugin-unicorn";
 import typescriptEslint from "typescript-eslint";
 
 export default typescriptEslint.config(
   eslint.configs.recommended,
   eslintConfigPrettier,
-  eslintPluginPerfectionistRecommendedNatural,
+  eslintPluginPerfectionistRecommendedNatural as Linter.Config,
   eslintPluginUnicorn.configs["flat/recommended"],
   ...typescriptEslint.configs.recommended,
   {
@@ -24,10 +26,11 @@ export default typescriptEslint.config(
       "@typescript-eslint/no-empty-function": "off",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
       "no-console": "off",
       "unicorn/consistent-function-scoping": "off",
       "unicorn/no-null": "off",
       "unicorn/no-useless-undefined": "off",
     },
   },
-);
+) as Linter.Config[];

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "eslint-plugin-perfectionist": "^2.11.0",
     "eslint-plugin-unicorn": "^57.0.0",
     "happy-dom": "^20.0.0",
+    "jiti": "^2.0.0",
     "jsdom": "^26.0.0",
     "knip": "^5.23.0",
     "prettier": "^3.3.2",
@@ -60,7 +61,7 @@
     "react-test-renderer": "^18.3.1",
     "tsup": "^8.1.0",
     "typescript": "^5.5.2",
-    "typescript-eslint": "^7.14.1",
+    "typescript-eslint": "^8.46.4",
     "vite": "^6.0.1",
     "vitest": "^1.6.0",
     "zod": "^4.1.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,19 +56,22 @@ importers:
         version: 3.1.4(vitest@1.6.1(@types/node@24.1.0)(happy-dom@20.0.0)(jsdom@26.1.0))
       eslint:
         specifier: ^9.5.0
-        version: 9.25.1(jiti@1.21.6)
+        version: 9.25.1(jiti@2.6.1)
       eslint-config-prettier:
         specifier: ^10.0.1
-        version: 10.1.8(eslint@9.25.1(jiti@1.21.6))
+        version: 10.1.8(eslint@9.25.1(jiti@2.6.1))
       eslint-plugin-perfectionist:
         specifier: ^2.11.0
-        version: 2.11.0(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)
+        version: 2.11.0(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-unicorn:
         specifier: ^57.0.0
-        version: 57.0.0(eslint@9.25.1(jiti@1.21.6))
+        version: 57.0.0(eslint@9.25.1(jiti@2.6.1))
       happy-dom:
         specifier: ^20.0.0
         version: 20.0.0
+      jiti:
+        specifier: ^2.0.0
+        version: 2.6.1
       jsdom:
         specifier: ^26.0.0
         version: 26.1.0
@@ -92,16 +95,16 @@ importers:
         version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.1.0
-        version: 8.5.0(jiti@1.21.6)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.4.5)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.4.5)
       typescript:
         specifier: ^5.5.2
         version: 5.9.3
       typescript-eslint:
-        specifier: ^7.14.1
-        version: 7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)
+        specifier: ^8.46.4
+        version: 8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)
       vite:
         specifier: ^6.0.1
-        version: 6.3.6(@types/node@24.1.0)(jiti@1.21.6)(yaml@2.4.5)
+        version: 6.3.6(@types/node@24.1.0)(jiti@2.6.1)(yaml@2.4.5)
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@24.1.0)(happy-dom@20.0.0)(jsdom@26.1.0)
@@ -703,6 +706,12 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -1097,44 +1106,55 @@ packages:
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
-  '@typescript-eslint/eslint-plugin@7.14.1':
-    resolution: {integrity: sha512-aAJd6bIf2vvQRjUG3ZkNXkmBpN+J7Wd0mfQiiVCJMu9Z5GcZZdcc0j8XwN/BM97Fl7e3SkTXODSk4VehUv7CGw==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/eslint-plugin@8.46.4':
+    resolution: {integrity: sha512-R48VhmTJqplNyDxCyqqVkFSZIx1qX6PzwqgcXn1olLrzxcSBDlOsbtcnQuQhNtnNiJ4Xe5gREI1foajYaYU2Vg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^7.0.0
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      '@typescript-eslint/parser': ^8.46.4
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@7.14.1':
-    resolution: {integrity: sha512-8lKUOebNLcR0D7RvlcloOacTOWzOqemWEWkKSVpMZVF/XVcwjPR+3MD08QzbW9TCGJ+DwIc6zUSGZ9vd8cO1IA==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/parser@8.46.4':
+    resolution: {integrity: sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.46.4':
+    resolution: {integrity: sha512-nPiRSKuvtTN+no/2N1kt2tUh/HoFzeEgOm9fQ6XQk4/ApGqjx0zFIIaLJ6wooR1HIoozvj2j6vTi/1fgAz7UYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/scope-manager@7.14.1':
     resolution: {integrity: sha512-gPrFSsoYcsffYXTOZ+hT7fyJr95rdVe4kGVX1ps/dJ+DfmlnjFN/GcMxXcVkeHDKqsq6uAcVaQaIi3cFffmAbA==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
-  '@typescript-eslint/type-utils@7.14.1':
-    resolution: {integrity: sha512-/MzmgNd3nnbDbOi3LfasXWWe292+iuo+umJ0bCCMCPc1jLO/z2BQmWUUUXvXLbrQey/JgzdF/OV+I5bzEGwJkQ==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  '@typescript-eslint/scope-manager@8.46.4':
+    resolution: {integrity: sha512-tMDbLGXb1wC+McN1M6QeDx7P7c0UWO5z9CXqp7J8E+xGcJuUuevWKxuG8j41FoweS3+L41SkyKKkia16jpX7CA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.46.4':
+    resolution: {integrity: sha512-+/XqaZPIAk6Cjg7NWgSGe27X4zMGqrFqZ8atJsX3CWxH/jACqWnrWI68h7nHQld0y+k9eTTjb9r+KU4twLoo9A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.46.4':
+    resolution: {integrity: sha512-V4QC8h3fdT5Wro6vANk6eojqfbv5bpwHuMsBcJUJkqs2z5XnYhJzyz9Y02eUmF9u3PgXEUiOt4w4KHR3P+z0PQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/types@7.14.1':
     resolution: {integrity: sha512-mL7zNEOQybo5R3AavY+Am7KLv8BorIv7HCYS5rKoNZKQD9tsfGUpO4KdAn3sSUvTiS4PQkr2+K0KJbxj8H9NDg==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/types@8.46.4':
+    resolution: {integrity: sha512-USjyxm3gQEePdUwJBFjjGNG18xY9A2grDVGuk7/9AkjIF1L+ZrVnwR5VAU5JXtUnBL/Nwt3H31KlRDaksnM7/w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@7.14.1':
     resolution: {integrity: sha512-k5d0VuxViE2ulIO6FbxxSZaxqDVUyMbXcidC8rHvii0I56XZPv8cq+EhMns+d/EVIL41sMXqRbK3D10Oza1bbA==}
@@ -1145,15 +1165,32 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@8.46.4':
+    resolution: {integrity: sha512-7oV2qEOr1d4NWNmpXLR35LvCfOkTNymY9oyW+lUHkmCno7aOmIf/hMaydnJBUTBMRCOGZh8YjkFOc8dadEoNGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/utils@7.14.1':
     resolution: {integrity: sha512-CMmVVELns3nak3cpJhZosDkm63n+DwBlDX8g0k4QUa9BMnF+lH2lr3d130M1Zt1xxmB3LLk3NV7KQCq86ZBBhQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@8.46.4':
+    resolution: {integrity: sha512-AbSv11fklGXV6T28dp2Me04Uw90R2iJ30g2bgLz529Koehrmkbs1r7paFqr1vPCZi7hHwYxYtxfyQMRC8QaVSg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
   '@typescript-eslint/visitor-keys@7.14.1':
     resolution: {integrity: sha512-Crb+F75U1JAEtBeQGxSKwI60hZmmzaqA3z9sYsVm8X7W5cwLEm5bRe0/uXS6+MR/y8CVpKSR/ontIAIEPFcEkA==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@8.46.4':
+    resolution: {integrity: sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitest/coverage-v8@3.1.4':
     resolution: {integrity: sha512-G4p6OtioySL+hPV7Y6JHlhpsODbJzt1ndwHAFkyk6vVjpK03PFsKnauZIzcd0PrK4zAbc5lc+jeZ+eNGiMA+iw==}
@@ -1515,6 +1552,10 @@ packages:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint@9.25.1:
     resolution: {integrity: sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1723,6 +1764,10 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
   immer@10.1.1:
     resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
 
@@ -1809,6 +1854,10 @@ packages:
 
   jiti@1.21.6:
     resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
+    hasBin: true
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   joycon@3.1.1:
@@ -2522,6 +2571,12 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  ts-api-utils@2.1.0:
+    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -2556,15 +2611,12 @@ packages:
     resolution: {integrity: sha512-w2IGJU1tIgcrepg9ZJ82d8UmItNQtOFJG0HCUE3SzMokKkTsruVDALl2fAdiEzJlfduoU+VyXJWIIUZ+6jV+nw==}
     engines: {node: '>=16'}
 
-  typescript-eslint@7.14.1:
-    resolution: {integrity: sha512-Eo1X+Y0JgGPspcANKjeR6nIqXl4VL5ldXLc15k4m9upq+eY5fhU2IueiEZL6jmHrKH8aCfbIvM/v3IrX5Hg99w==}
-    engines: {node: ^18.18.0 || >=20.0.0}
+  typescript-eslint@8.46.4:
+    resolution: {integrity: sha512-KALyxkpYV5Ix7UhvjTwJXZv76VWsHG+NjNlt/z+a17SOQSiOcBdUXdbJdyXi7RPxrBFECtFOiPwUJQusJuCqrg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -3258,14 +3310,19 @@ snapshots:
   '@esbuild/win32-x64@0.25.9':
     optional: true
 
-  '@eslint-community/eslint-utils@4.5.1(eslint@9.25.1(jiti@1.21.6))':
+  '@eslint-community/eslint-utils@4.5.1(eslint@9.25.1(jiti@2.6.1))':
     dependencies:
-      eslint: 9.25.1(jiti@1.21.6)
+      eslint: 9.25.1(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.6.1(eslint@9.25.1(jiti@1.21.6))':
+  '@eslint-community/eslint-utils@4.6.1(eslint@9.25.1(jiti@2.6.1))':
     dependencies:
-      eslint: 9.25.1(jiti@1.21.6)
+      eslint: 9.25.1(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.25.1(jiti@2.6.1))':
+    dependencies:
+      eslint: 9.25.1(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -3590,33 +3647,40 @@ snapshots:
 
   '@types/whatwg-mimetype@3.0.2': {}
 
-  '@typescript-eslint/eslint-plugin@7.14.1(@typescript-eslint/parser@7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3))(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.46.4(@typescript-eslint/parser@8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 7.14.1
-      '@typescript-eslint/type-utils': 7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 7.14.1
-      eslint: 9.25.1(jiti@1.21.6)
+      '@typescript-eslint/parser': 8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.46.4
+      '@typescript-eslint/type-utils': 8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.46.4
+      eslint: 9.25.1(jiti@2.6.1)
       graphemer: 1.4.0
-      ignore: 5.3.2
+      ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.9.3)
-    optionalDependencies:
+      ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 7.14.1
-      '@typescript-eslint/types': 7.14.1
-      '@typescript-eslint/typescript-estree': 7.14.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 7.14.1
+      '@typescript-eslint/scope-manager': 8.46.4
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.46.4
       debug: 4.4.1
-      eslint: 9.25.1(jiti@1.21.6)
-    optionalDependencies:
+      eslint: 9.25.1(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.46.4(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.46.4
+      debug: 4.4.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3626,19 +3690,30 @@ snapshots:
       '@typescript-eslint/types': 7.14.1
       '@typescript-eslint/visitor-keys': 7.14.1
 
-  '@typescript-eslint/type-utils@7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)':
+  '@typescript-eslint/scope-manager@8.46.4':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.14.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/visitor-keys': 8.46.4
+
+  '@typescript-eslint/tsconfig-utils@8.46.4(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.1
-      eslint: 9.25.1(jiti@1.21.6)
-      ts-api-utils: 1.3.0(typescript@5.9.3)
-    optionalDependencies:
+      eslint: 9.25.1(jiti@2.6.1)
+      ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@7.14.1': {}
+
+  '@typescript-eslint/types@8.46.4': {}
 
   '@typescript-eslint/typescript-estree@7.14.1(typescript@5.9.3)':
     dependencies:
@@ -3655,21 +3730,53 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.46.4(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.25.1(jiti@1.21.6))
+      '@typescript-eslint/project-service': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/visitor-keys': 8.46.4
+      debug: 4.4.1
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.2
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@7.14.1(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.6.1(eslint@9.25.1(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 7.14.1
       '@typescript-eslint/types': 7.14.1
       '@typescript-eslint/typescript-estree': 7.14.1(typescript@5.9.3)
-      eslint: 9.25.1(jiti@1.21.6)
+      eslint: 9.25.1(jiti@2.6.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@typescript-eslint/utils@8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.25.1(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.46.4
+      '@typescript-eslint/types': 8.46.4
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
+      eslint: 9.25.1(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/visitor-keys@7.14.1':
     dependencies:
       '@typescript-eslint/types': 7.14.1
       eslint-visitor-keys: 3.4.3
+
+  '@typescript-eslint/visitor-keys@8.46.4':
+    dependencies:
+      '@typescript-eslint/types': 8.46.4
+      eslint-visitor-keys: 4.2.1
 
   '@vitest/coverage-v8@3.1.4(vitest@1.6.1(@types/node@24.1.0)(happy-dom@20.0.0)(jsdom@26.1.0))':
     dependencies:
@@ -4031,28 +4138,28 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.25.1(jiti@1.21.6)):
+  eslint-config-prettier@10.1.8(eslint@9.25.1(jiti@2.6.1)):
     dependencies:
-      eslint: 9.25.1(jiti@1.21.6)
+      eslint: 9.25.1(jiti@2.6.1)
 
-  eslint-plugin-perfectionist@2.11.0(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3):
+  eslint-plugin-perfectionist@2.11.0(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)
-      eslint: 9.25.1(jiti@1.21.6)
+      '@typescript-eslint/utils': 7.14.1(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.25.1(jiti@2.6.1)
       minimatch: 9.0.5
       natural-compare-lite: 1.4.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-unicorn@57.0.0(eslint@9.25.1(jiti@1.21.6)):
+  eslint-plugin-unicorn@57.0.0(eslint@9.25.1(jiti@2.6.1)):
     dependencies:
       '@babel/helper-validator-identifier': 7.25.9
-      '@eslint-community/eslint-utils': 4.5.1(eslint@9.25.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.5.1(eslint@9.25.1(jiti@2.6.1))
       ci-info: 4.2.0
       clean-regexp: 1.0.0
       core-js-compat: 3.41.0
-      eslint: 9.25.1(jiti@1.21.6)
+      eslint: 9.25.1(jiti@2.6.1)
       esquery: 1.6.0
       globals: 15.15.0
       indent-string: 5.0.0
@@ -4074,9 +4181,11 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
-  eslint@9.25.1(jiti@1.21.6):
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.25.1(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.25.1(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.6.1(eslint@9.25.1(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.20.0
       '@eslint/config-helpers': 0.2.1
@@ -4112,7 +4221,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 1.21.6
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4323,6 +4432,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  ignore@7.0.5: {}
+
   immer@10.1.1: {}
 
   import-fresh@3.3.1:
@@ -4394,6 +4505,8 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   jiti@1.21.6: {}
+
+  jiti@2.6.1: {}
 
   joycon@3.1.1: {}
 
@@ -4710,11 +4823,11 @@ snapshots:
 
   pluralize@8.0.0: {}
 
-  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.5.6)(yaml@2.4.5):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.4.5):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 1.21.6
+      jiti: 2.6.1
       postcss: 8.5.6
       yaml: 2.4.5
 
@@ -5077,9 +5190,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  ts-api-utils@2.1.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.0(jiti@1.21.6)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.4.5):
+  tsup@8.5.0(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.4.5):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.5)
       cac: 6.7.14
@@ -5090,7 +5207,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.5.6)(yaml@2.4.5)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.4.5)
       resolve-from: 5.0.0
       rollup: 4.41.1
       source-map: 0.8.0-beta.0
@@ -5115,13 +5232,13 @@ snapshots:
 
   type-fest@4.39.0: {}
 
-  typescript-eslint@7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3):
+  typescript-eslint@8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.14.1(@typescript-eslint/parser@7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3))(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)
-      '@typescript-eslint/parser': 7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.14.1(eslint@9.25.1(jiti@1.21.6))(typescript@5.9.3)
-      eslint: 9.25.1(jiti@1.21.6)
-    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.46.4(@typescript-eslint/parser@8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.4(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.4(eslint@9.25.1(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.25.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5184,7 +5301,7 @@ snapshots:
       '@types/node': 24.1.0
       fsevents: 2.3.3
 
-  vite@6.3.6(@types/node@24.1.0)(jiti@1.21.6)(yaml@2.4.5):
+  vite@6.3.6(@types/node@24.1.0)(jiti@2.6.1)(yaml@2.4.5):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5195,7 +5312,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.1.0
       fsevents: 2.3.3
-      jiti: 1.21.6
+      jiti: 2.6.1
       yaml: 2.4.5
 
   vitest@1.6.1(@types/node@24.1.0)(happy-dom@20.0.0)(jsdom@26.1.0):


### PR DESCRIPTION
- Migrate eslint.config.mjs to eslint.config.ts with proper type annotations
- Install jiti@2.6.1 for Node.js TypeScript config support
- Upgrade ESLint to 9.25.1 (stable TypeScript config support added in 9.18.0)
- Upgrade typescript-eslint to 8.46.4 for ESLint 9 compatibility
- Add @typescript-eslint/no-unused-expressions exception for test files
- Remove TODO comments for type imports (now fully typed)
- Fix Prettier formatting in AGENTS.md and CLAUDE.md

Fixes #317