### PR TITLE
Enforce valid endpoint options by type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is **trpc-rtk-query**, a TypeScript library that automatically generates RTK Query API endpoints from tRPC router setups. It enables type-safe RTK Query hooks from tRPC procedures, perfect for incremental adoption from tRPC to RTK Query.
 
 **Project Status:**
+
 - Library is in **alpha stage** (0.x.x versions) - not production ready
 - **41 stars, 6 forks** - small but engaged community
 - Uses **pnpm** as package manager (minimum Node.js 20)
@@ -16,6 +17,7 @@ This is **trpc-rtk-query**, a TypeScript library that automatically generates RT
 ## Common Development Commands
 
 **Core Development:**
+
 - `pnpm test` - Run all tests using Vitest
 - `pnpm run coverage` - Run tests with coverage report
 - `pnpm run typecheck` - Run TypeScript type checking only (via Vitest)
@@ -23,20 +25,24 @@ This is **trpc-rtk-query**, a TypeScript library that automatically generates RT
 - `pnpm run build` - Build the library using tsup
 
 **Release Management:**
+
 - `pnpm run changeset` - Create a changeset for versioning
 - `pnpm run release` - Build and publish (runs build + changeset publish)
 
 **Code Quality:**
+
 - `pnpm run knip` - Find unused dependencies and exports
 
 **Running Single Tests:**
 Use Vitest's built-in filtering:
+
 - `pnpm test create-trpc-api` - Run tests matching the pattern
 - `pnpm test -- --typecheck.only` - Run only type tests
 
 ## Architecture Overview
 
 **Core Library Structure:**
+
 - `src/api.ts` - Main API with `enhanceApi()` and `createEmptyApi()` functions
 - `src/create-endpoint-definitions.ts` - Complex TypeScript types that transform tRPC router types into RTK Query endpoint definitions
 - `src/wrap-api-to-proxy.ts` - Proxy wrapper that dynamically creates RTK Query endpoints from tRPC client calls
@@ -44,17 +50,20 @@ Use Vitest's built-in filtering:
 - `src/trpc-client-options.ts` - Type definitions for tRPC client configuration
 
 **Key Concepts:**
+
 1. **Type Transformation**: The library uses advanced TypeScript to flatten nested tRPC routers into RTK Query endpoint definitions
 2. **Runtime Proxy**: Uses JavaScript Proxy to intercept property access and dynamically inject RTK Query endpoints
 3. **Endpoint Naming**: Nested routes are flattened with underscore separation (e.g., `nested.deep.getUser` becomes `nested_deep_GetUser`)
 
 **Test Architecture:**
+
 - Uses Vitest with happy-dom environment
 - `test/fixtures.ts` contains a comprehensive test tRPC router with nested routes, queries, and mutations
 - Type-level tests use `.test-d.ts` files for TypeScript assertion testing
 - Integration tests verify the full tRPC → RTK Query transformation
 
 **Build System:**
+
 - Uses `tsup` for building with both CJS and ESM outputs
 - TypeScript builds reference `tsconfig.build.json`
 - Supports both Node.js require() and ESM import()
@@ -68,6 +77,7 @@ The `CreateEndpointDefinitions` type in `create-endpoint-definitions.ts` is the 
 The `wrapApiToProxy` function creates a Proxy that intercepts property access and uses RTK Query's `injectEndpoints` to dynamically add tRPC-backed endpoints at runtime.
 
 **Testing Strategy:**
+
 - Type-level tests ensure the complex type transformations work correctly
 - Integration tests verify the runtime behavior with actual tRPC routers
 - Snapshot testing captures the generated RTK Query endpoint structure
@@ -77,7 +87,9 @@ The `wrapApiToProxy` function creates a Proxy that intercepts property access an
 Based on open GitHub issues, focus development efforts on:
 
 **High Priority (Blocking/Important):**
+
 1. **tRPC v11 Upgrade (#406)** - Major version update needed to stay current
+
    - Review migration guide: https://trpc.io/docs/v11/migration-guide
    - Update dependencies and test compatibility
    - Consider adopting new features (FormData support, streaming queries)
@@ -89,12 +101,10 @@ Based on open GitHub issues, focus development efforts on:
    - Server-side rendering (SSR) example
    - React Native integration example
 
-**Medium Priority (Quality & DX):**
-3. **Improve Documentation (#44)** - Write comprehensive docs and improve README
-4. **ESLint TypeScript Migration (#317)** - Convert flat config when ESLint stabilizes TS support
-5. **E2E Testing (#43)** - Test built library version in real React projects
+**Medium Priority (Quality & DX):** 3. **Improve Documentation (#44)** - Write comprehensive docs and improve README 4. **ESLint TypeScript Migration (#317)** - Convert flat config when ESLint stabilizes TS support 5. **E2E Testing (#43)** - Test built library version in real React projects
 
 **Technical Debt:**
+
 - Fix tagTypes type checking (#64)
 - Improve endpoint options flow through proxy (#47)
 - Add stricter validation for endpointOptions (#46)
@@ -104,16 +114,19 @@ Based on open GitHub issues, focus development efforts on:
 ## Known Issues & Gotchas
 
 **TypeScript Complexity:**
+
 - Advanced type transformations can cause "excessively deep instantiation" errors
 - The `CreateEndpointDefinitions` type is particularly complex - modify carefully
 - Type checking issues with tagTypes and endpoint options still exist
 
 **Dependency Management:**
+
 - Excellent automated updates via Dependabot (95%+ of recent PRs)
 - Watch for major version compatibility issues (previous issues with pnpm versions)
 - Support requires specific minimum versions: tRPC v10+, RTK Query v2+
 
 **Development Workflow:**
+
 - Last major feature development: June 2024 (ESLint 9 migration)
 - Pattern: Bursts of development followed by maintenance-only phases
 - Owner responsive to issues but development happens in cycles

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This is **trpc-rtk-query**, a TypeScript library that automatically generates RTK Query API endpoints from tRPC router setups. It enables type-safe RTK Query hooks from tRPC procedures, perfect for incremental adoption from tRPC to RTK Query.
 
 **Project Status:**
+
 - Library is in **alpha stage** (0.x.x versions) - not production ready
 - **41 stars, 6 forks** - small but engaged community
 - Uses **pnpm** as package manager (minimum Node.js 20)
@@ -16,6 +17,7 @@ This is **trpc-rtk-query**, a TypeScript library that automatically generates RT
 ## Common Development Commands
 
 **Core Development:**
+
 - `pnpm test` - Run all tests using Vitest
 - `pnpm run coverage` - Run tests with coverage report
 - `pnpm run typecheck` - Run TypeScript type checking only (via Vitest)
@@ -23,20 +25,24 @@ This is **trpc-rtk-query**, a TypeScript library that automatically generates RT
 - `pnpm run build` - Build the library using tsup
 
 **Release Management:**
+
 - `pnpm run changeset` - Create a changeset for versioning
 - `pnpm run release` - Build and publish (runs build + changeset publish)
 
 **Code Quality:**
+
 - `pnpm run knip` - Find unused dependencies and exports
 
 **Running Single Tests:**
 Use Vitest's built-in filtering:
+
 - `pnpm test create-trpc-api` - Run tests matching the pattern
 - `pnpm test -- --typecheck.only` - Run only type tests
 
 ## Architecture Overview
 
 **Core Library Structure:**
+
 - `src/api.ts` - Main API with `enhanceApi()` and `createEmptyApi()` functions
 - `src/create-endpoint-definitions.ts` - Complex TypeScript types that transform tRPC router types into RTK Query endpoint definitions
 - `src/wrap-api-to-proxy.ts` - Proxy wrapper that dynamically creates RTK Query endpoints from tRPC client calls
@@ -44,17 +50,20 @@ Use Vitest's built-in filtering:
 - `src/trpc-client-options.ts` - Type definitions for tRPC client configuration
 
 **Key Concepts:**
+
 1. **Type Transformation**: The library uses advanced TypeScript to flatten nested tRPC routers into RTK Query endpoint definitions
 2. **Runtime Proxy**: Uses JavaScript Proxy to intercept property access and dynamically inject RTK Query endpoints
 3. **Endpoint Naming**: Nested routes are flattened with underscore separation (e.g., `nested.deep.getUser` becomes `nested_deep_GetUser`)
 
 **Test Architecture:**
+
 - Uses Vitest with happy-dom environment
 - `test/fixtures.ts` contains a comprehensive test tRPC router with nested routes, queries, and mutations
 - Type-level tests use `.test-d.ts` files for TypeScript assertion testing
 - Integration tests verify the full tRPC → RTK Query transformation
 
 **Build System:**
+
 - Uses `tsup` for building with both CJS and ESM outputs
 - TypeScript builds reference `tsconfig.build.json`
 - Supports both Node.js require() and ESM import()
@@ -68,6 +77,7 @@ The `CreateEndpointDefinitions` type in `create-endpoint-definitions.ts` is the 
 The `wrapApiToProxy` function creates a Proxy that intercepts property access and uses RTK Query's `injectEndpoints` to dynamically add tRPC-backed endpoints at runtime.
 
 **Testing Strategy:**
+
 - Type-level tests ensure the complex type transformations work correctly
 - Integration tests verify the runtime behavior with actual tRPC routers
 - Snapshot testing captures the generated RTK Query endpoint structure
@@ -77,7 +87,9 @@ The `wrapApiToProxy` function creates a Proxy that intercepts property access an
 Based on open GitHub issues, focus development efforts on:
 
 **High Priority (Blocking/Important):**
+
 1. **tRPC v11 Upgrade (#406)** - Major version update needed to stay current
+
    - Review migration guide: https://trpc.io/docs/v11/migration-guide
    - Update dependencies and test compatibility
    - Consider adopting new features (FormData support, streaming queries)
@@ -89,12 +101,10 @@ Based on open GitHub issues, focus development efforts on:
    - Server-side rendering (SSR) example
    - React Native integration example
 
-**Medium Priority (Quality & DX):**
-3. **Improve Documentation (#44)** - Write comprehensive docs and improve README
-4. **ESLint TypeScript Migration (#317)** - Convert flat config when ESLint stabilizes TS support
-5. **E2E Testing (#43)** - Test built library version in real React projects
+**Medium Priority (Quality & DX):** 3. **Improve Documentation (#44)** - Write comprehensive docs and improve README 4. **ESLint TypeScript Migration (#317)** - Convert flat config when ESLint stabilizes TS support 5. **E2E Testing (#43)** - Test built library version in real React projects
 
 **Technical Debt:**
+
 - Fix tagTypes type checking (#64)
 - Improve endpoint options flow through proxy (#47)
 - Add stricter validation for endpointOptions (#46)
@@ -104,16 +114,19 @@ Based on open GitHub issues, focus development efforts on:
 ## Known Issues & Gotchas
 
 **TypeScript Complexity:**
+
 - Advanced type transformations can cause "excessively deep instantiation" errors
 - The `CreateEndpointDefinitions` type is particularly complex - modify carefully
 - Type checking issues with tagTypes and endpoint options still exist
 
 **Dependency Management:**
+
 - Excellent automated updates via Dependabot (95%+ of recent PRs)
 - Watch for major version compatibility issues (previous issues with pnpm versions)
 - Support requires specific minimum versions: tRPC v10+, RTK Query v2+
 
 **Development Workflow:**
+
 - Last major feature development: June 2024 (ESLint 9 migration)
 - Pattern: Bursts of development followed by maintenance-only phases
 - Owner responsive to issues but development happens in cycles

--- a/src/api.ts
+++ b/src/api.ts
@@ -10,7 +10,7 @@ import { type AnyRouter } from "@trpc/server";
 import { type CreateEndpointDefinitions } from "./create-endpoint-definitions.js";
 import { type AnyApi, type SupportedModule } from "./rtk-types.js";
 import { type TRPCClientOptions } from "./trpc-client-options.js";
-import { type DisabledEndpointOptions, wrapApiToProxy } from "./wrap-api-to-proxy.js";
+import { type EndpointOptions, wrapApiToProxy } from "./wrap-api-to-proxy.js";
 
 /**
  * Generic type for api that has injectEndpoint method for run time injection and
@@ -55,10 +55,7 @@ export const enhanceApi = <
 >(
   options: {
     api: ExistingApi;
-  } & {
-    endpointOptions?: {
-      [K in keyof NewDefinitions]?: Omit<NewDefinitions[K], DisabledEndpointOptions>;
-    };
+    endpointOptions?: EndpointOptions<NewDefinitions>;
   } & TRPCClientOptions<TRouter>,
 ) =>
   wrapApiToProxy({

--- a/test/endpoint-options-validation.test-d.ts
+++ b/test/endpoint-options-validation.test-d.ts
@@ -1,0 +1,172 @@
+import { createApi } from "@reduxjs/toolkit/query/react";
+import { createTRPCProxyClient } from "@trpc/client";
+import { describe, it } from "vitest";
+
+import { enhanceApi } from "../src/index.js";
+import { type AppRouter, testClientOptions } from "./fixtures.js";
+
+describe("endpoint options validation", () => {
+  const client = createTRPCProxyClient<AppRouter>(testClientOptions);
+  const existingApi = createApi({
+    baseQuery: (string_: string) => {
+      return {
+        data: {
+          string_,
+        },
+      };
+    },
+    endpoints: (builder) => ({
+      getResponse: builder.query<string, string>({
+        query: (string_: string) => string_,
+      }),
+    }),
+    reducerPath: "premadeApi",
+    tagTypes: ["User"],
+  });
+
+  describe("query endpoints", () => {
+    it("allows providesTags on query endpoints", () => {
+      // This should compile without errors
+      enhanceApi({
+        api: existingApi,
+        client,
+        endpointOptions: {
+          getUserById: {
+            providesTags: (result) => [{ id: result?.id, type: "User" }],
+          },
+        },
+      });
+    });
+
+    it("allows other query-specific options", () => {
+      // This should compile without errors
+      enhanceApi({
+        api: existingApi,
+        client,
+        endpointOptions: {
+          getUserById: {
+            keepUnusedDataFor: 60,
+          },
+        },
+      });
+    });
+
+    it("disallows invalidatesTags on query endpoints", () => {
+      // First verify that providesTags works (positive test)
+      enhanceApi({
+        api: existingApi,
+        client,
+        endpointOptions: {
+          getUserById: {
+            providesTags: ["User"], // This should work
+          },
+        },
+      });
+
+      // Now test that invalidatesTags doesn't work (negative test)
+      enhanceApi({
+        api: existingApi,
+        client,
+        endpointOptions: {
+          getUserById: {
+            // @ts-expect-error - invalidatesTags should not be allowed on queries
+            invalidatesTags: ["User"],
+          },
+        },
+      });
+    });
+  });
+
+  describe("mutation endpoints", () => {
+    it("allows invalidatesTags on mutation endpoints", () => {
+      // This should compile without errors
+      enhanceApi({
+        api: existingApi,
+        client,
+        endpointOptions: {
+          updateName: {
+            invalidatesTags: ["User"],
+          },
+        },
+      });
+    });
+
+    it("allows structuralSharing option on mutation endpoints", () => {
+      // This should compile without errors
+      enhanceApi({
+        api: existingApi,
+        client,
+        endpointOptions: {
+          updateName: {
+            structuralSharing: false,
+          },
+        },
+      });
+    });
+
+    it("disallows providesTags on mutation endpoints", () => {
+      enhanceApi({
+        api: existingApi,
+        client,
+        endpointOptions: {
+          updateName: {
+            // @ts-expect-error - providesTags should not be allowed on mutations
+            providesTags: ["User"],
+          },
+        },
+      });
+    });
+
+    it("disallows query-specific options on mutation endpoints", () => {
+      enhanceApi({
+        api: existingApi,
+        client,
+        endpointOptions: {
+          updateName: {
+            // @ts-expect-error - merge is query-specific and not allowed on mutations
+            merge: (currentCache, newData) => {
+              return newData;
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe("multiple endpoints with mixed types", () => {
+    it("correctly discriminates between query and mutation options", () => {
+      // This should compile without errors
+      enhanceApi({
+        api: existingApi,
+        client,
+        endpointOptions: {
+          getUserById: {
+            // Query endpoint - providesTags is allowed
+            providesTags: (result) => [{ id: result?.id, type: "User" }],
+          },
+          updateName: {
+            // Mutation endpoint - invalidatesTags is allowed
+            invalidatesTags: ["User"],
+          },
+        },
+      });
+    });
+
+    it("prevents cross-contamination of options", () => {
+      enhanceApi({
+        api: existingApi,
+        client,
+        endpointOptions: {
+          getUserById: {
+            // @ts-expect-error - invalidatesTags should not be allowed on query
+            invalidatesTags: ["User"],
+          },
+          updateName: {
+            // @ts-expect-error - providesTags should not be allowed on mutation
+            providesTags: ["User"],
+          },
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit implements proper type discrimination for endpoint options, preventing users from passing mutation-only options to queries and vice versa.

Changes:
- Added `ExtractEndpointOptions` type that preserves RTK Query's discriminated union between QueryDefinition and MutationDefinition
- Created `EndpointOptions` helper type that maintains the relationship between endpoint names and their specific definition types
- Updated `enhanceApi` to use the new type-safe endpoint options
- Added comprehensive type-level tests in endpoint-options-validation.test-d.ts

Key improvements:
✓ Queries can only have query-specific options (providesTags, merge, forceRefetch, etc.) ✓ Mutations can only have mutation-specific options (invalidatesTags, etc.) ✓ TypeScript will now show errors when invalid options are used ✓ Preserves RTK Query's never types for proper discrimination

Related: #47 (endpoint options flow)