### PR TITLE
Fix queryFn type definitions in endpoint

### DIFF
--- a/.changeset/fix-queryfn-types.md
+++ b/.changeset/fix-queryfn-types.md
@@ -1,0 +1,7 @@
+---
+"trpc-rtk-query": patch
+---
+
+Fix queryFn type definitions to use proper types instead of any
+
+The queryFn in endpoint definitions now uses BaseQueryApi and TRPCRequestOptions types instead of any, providing better type safety when working with custom queryFn implementations. This resolves issue #41.

--- a/src/wrap-api-to-proxy.ts
+++ b/src/wrap-api-to-proxy.ts
@@ -1,4 +1,8 @@
-import { type EndpointDefinitions } from "@reduxjs/toolkit/query/react";
+import {
+  type BaseQueryApi,
+  type EndpointDefinitions,
+} from "@reduxjs/toolkit/query/react";
+import { type TRPCRequestOptions } from "@trpc/client";
 import { type AnyRouter } from "@trpc/server";
 import { isPlainObject, isString } from "is-what";
 
@@ -87,9 +91,11 @@ const injectEndpointToApi = <Api extends Injectable, TRouter extends AnyRouter>(
     : endpoint;
 
   const builderArguments = {
-    // TODO: https://github.com/otahontas/trpc-rtk-query/issues/41
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    queryFn: (procedureArguments: unknown, api: any, extraOptions: any) =>
+    queryFn: (
+      procedureArguments: unknown,
+      api: BaseQueryApi,
+      extraOptions: TRPCRequestOptions,
+    ) =>
       createTRPCBaseQuery(options.tRPCClientOptions)(
         {
           procedureArguments,


### PR DESCRIPTION
Replace 'any' types in queryFn with proper types:
- api parameter now uses BaseQueryApi from RTK Query
- extraOptions parameter now uses TRPCRequestOptions from tRPC

This provides better type safety for users working with custom queryFn implementations and fixes the type checking issues reported in issue #41.

- Remove TODO comment and eslint-disable comment that are no longer needed
- Add proper imports for BaseQueryApi and TRPCRequestOptions
- Update type definitions to match RTK Query's queryFn signature

All existing tests pass and type checking succeeds.